### PR TITLE
Disabled virticle chest grouping to fix a bug.

### DIFF
--- a/src/main/java/com/daemitus/deadbolt/Deadbolted.java
+++ b/src/main/java/com/daemitus/deadbolt/Deadbolted.java
@@ -84,7 +84,7 @@ public final class Deadbolted {
                 searchFurnace(block, plugin.config.group_furnaces, plugin.config.group_furnaces);
                 break;
             case CHEST:
-                searchChest(block, true, true);
+                searchChest(block, true, false);
                 break;
             default:
                 for (BlockFace bf : plugin.config.CARDINAL_FACES) {


### PR DESCRIPTION
If you place a chest 2 blocks below another players chest, private the bottom chest, and place a chest in the middle, you can access the top chest, by disabling virticle chest grouping, this bug is fixed(or disabled).
