### PR TITLE
Allow quicksign on trapped chests and add permissions to default plugin.yml

### DIFF
--- a/src/main/java/com/daemitus/deadbolt/events/PlayerListener.java
+++ b/src/main/java/com/daemitus/deadbolt/events/PlayerListener.java
@@ -74,6 +74,7 @@ public class PlayerListener implements Listener {
             case WOODEN_DOOR:
             case IRON_DOOR_BLOCK:
             case TRAP_DOOR:
+            case TRAPPED_CHEST:
             case FENCE_GATE:
             case BREWING_STAND:
             case ENCHANTMENT_TABLE:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,6 +40,7 @@ permissions:
       deadbolt.user.create.door: true
       deadbolt.user.create.furnace: true
       deadbolt.user.create.trapdoor: true
+      deadbolt.user.create.trappedchest: true
       deadbolt.user.create.fencegate: true
       deadbolt.user.create.brewery: true
       deadbolt.user.create.cauldron: true
@@ -58,6 +59,9 @@ permissions:
     default: true
   deadbolt.user.create.trapdoor:
     description: Allows user protection of trapdoors
+    default: true
+  deadbolt.user.create.trappedchest:
+    description: Allows user protection of trapped chests
     default: true
   deadbolt.user.create.fencegate:
     description: Allows user protection of fencegates


### PR DESCRIPTION
This brings trapped chest behavior in line with normal chest behavior.
