### PR TITLE
Add support for UUIDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 /nbproject
 /build.xml
 
+# IntelliJ IDEA
+.idea/
+/*.iml
+out/
+
 # vim
 .*.sw[a-p]
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.6.4-R2.0</version>
+            <version>1.7.9-R0.2</version>
         </dependency>
         <dependency>
             <groupId>com.md_5</groupId>

--- a/src/main/java/com/daemitus/deadbolt/Deadbolt.java
+++ b/src/main/java/com/daemitus/deadbolt/Deadbolt.java
@@ -1,6 +1,7 @@
 package com.daemitus.deadbolt;
 
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Logger;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -64,7 +65,7 @@ public final class Deadbolt {
      * @return A List<String> containing everything on any [Private] or [More
      * Users] signs associated with <block>
      */
-    public static Set<String> getAllNames(Block block) {
+    public static Set<UUID> getAllUsers(Block block) {
         return new Deadbolted(block).getUsers();
     }
 
@@ -72,10 +73,10 @@ public final class Deadbolt {
      * Retrieves owner of <block>
      *
      * @param block Block to be checked
-     * @return The text on the line below [Private] on the sign associated with
+     * @return The name of the line below [Private] on the sign associated with
      * <block>. null if unprotected
      */
-    public static String getOwnerName(Block block) {
+    public static UUID getOwner(Block block) {
         return new Deadbolted(block).getOwner();
     }
 

--- a/src/main/java/com/daemitus/deadbolt/DeadboltCommandExecutor.java
+++ b/src/main/java/com/daemitus/deadbolt/DeadboltCommandExecutor.java
@@ -83,12 +83,15 @@ public class DeadboltCommandExecutor implements CommandExecutor {
         Sign sign = (Sign) block.getState();
         String lines[] = sign.getLines();
 
-        String text = "";
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
         for (int i = 1; i < args.length; i++) {
-            text += args[i] + (i + 1 < args.length ? " " : "");
+            if (first) first = false;
+            else sb.append(' ');
+            sb.append(args[i]);
         }
 
-        text = Util.formatForSign(text);
+        String text = sb.toString();
         if (lineNum == 0) {
             if (!Util.removeColor(lines[0]).equalsIgnoreCase(Util.removeColor(text))) {
                 Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().cmd_identifier_not_changeable);
@@ -102,7 +105,8 @@ public class DeadboltCommandExecutor implements CommandExecutor {
                 }
             }
         }
-        lines[lineNum] = text;
+
+        lines[lineNum] = UUIDs.isName(text) ? UUIDs.formatName(text) : text; // TODO: Not a player?
 
         if (Deadbolt.getConfig().clear_sign_selection) {
             Deadbolt.getConfig().selectedSign.remove(player);
@@ -119,7 +123,8 @@ public class DeadboltCommandExecutor implements CommandExecutor {
                 lines[i] = Util.formatForSign(lines[i]);
             }
         }
-        sign.update(true);
+        sign.update();
+        UUIDs.deobfuscate(sign, player);
         Deadbolt.getConfig().sendMessage(player, ChatColor.GOLD, Deadbolt.getLanguage().cmd_sign_updated);
         return true;
     }
@@ -133,7 +138,7 @@ public class DeadboltCommandExecutor implements CommandExecutor {
                 fixHelper(player, block);
             } else if (player.hasPermission(Perm.admin_commands)) {
                 fixHelper(player, block);
-                Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().msg_admin_block_fixed, db.getOwner());
+                Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().msg_admin_block_fixed, db.getOwnerName());
             } else {
                 Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().cmd_fix_notowned);
             }
@@ -164,7 +169,7 @@ public class DeadboltCommandExecutor implements CommandExecutor {
             if (db.isOwner(player)) {
                 fixAllHelper(player, block, db);
             } else if (player.hasPermission(Perm.admin_commands)) {
-                Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().msg_admin_block_fixed, db.getOwner());
+                Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().msg_admin_block_fixed, db.getOwnerName());
                 fixAllHelper(player, block, db);
             } else {
                 Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().cmd_fix_notowned);

--- a/src/main/java/com/daemitus/deadbolt/PlayerNameUtil.java
+++ b/src/main/java/com/daemitus/deadbolt/PlayerNameUtil.java
@@ -1,19 +1,14 @@
 package com.daemitus.deadbolt;
 
-import java.io.File;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.Plugin;
 
 public class PlayerNameUtil implements Listener {
@@ -26,24 +21,13 @@ public class PlayerNameUtil implements Listener {
      * This is the latest created instance of this class.
      */
     public static PlayerNameUtil i = null;
-    
-    /**
-     * We will use this folder later. 
-     */
-    public static File playerfolder = new File(Bukkit.getWorlds().get(0).getWorldFolder(), "players");
-    
-    /**
-     * This map is populated using the player.dat files on disk.
-     * It is also populated when a player tries to log in to the server.
-     */
-    protected static Map<String, String> nameToCorrectName = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
-    
+
     /**
      * This map is used to improve the speed of name start lookups.
      * Note that the keys in this map is lowercase.
      */
-    protected static Map<String, Set<String>> lowerCaseStartOfNameToCorrectNames = new TreeMap<String, Set<String>>();
-    
+    protected static Map<String, String> lowerCaseStartOfNameToCorrectNames = new TreeMap<String, String>();
+
     /**
      * Did we populate the map yet?
      */
@@ -56,27 +40,17 @@ public class PlayerNameUtil implements Listener {
     public PlayerNameUtil(Plugin plugin) {
         i = this;
         Bukkit.getPluginManager().registerEvents(this, plugin);
-        if ( ! isPopulated) {
+        if ( !isPopulated) {
             populateCaseInsensitiveNameToCaseCorrectName();
             isPopulated = true;
         }
     }
     
     @EventHandler(priority = EventPriority.LOWEST)
-    public synchronized void onLowestPlayerPreLoginEvent(PlayerPreLoginEvent event)
+    // We can't use AsyncPlayerPreLoginEvent because that's not reliable on CraftBukkit
+    public synchronized void onLowestPlayerPreLoginEvent(PlayerLoginEvent event)
     {
-        String newPlayerName = event.getName();
-        String lowercaseNewPlayerName = newPlayerName.toLowerCase();
-        
-        // Add this name to the case-corrector map
-        nameToCorrectName.put(newPlayerName, newPlayerName);
-        
-        // Update the cache
-        for (Entry<String, Set<String>> entry : lowerCaseStartOfNameToCorrectNames.entrySet()) {
-            if (lowercaseNewPlayerName.startsWith(entry.getKey())) {
-                entry.getValue().add(newPlayerName);
-            }
-        }
+        checkPlayer(event.getPlayer());
     }
     
     // -------------------------------------------- //
@@ -84,113 +58,56 @@ public class PlayerNameUtil implements Listener {
     // -------------------------------------------- //
     
     /**
-     * This method simply checks if the playerName is a valid one.
-     * Mojangs rules for Minecraft character registration is used.
-     */
-    public static boolean isValidPlayerName(final String playerName) {
-        return Pattern.matches("^[a-zA-Z0-9_]{2,16}$", playerName);
-    }
-    
-    /**
-     * This method takes a player name and returns the same name but with correct case.
-     * Null is returned if the correct case can not be determined.
-     */
-    public static String fixPlayerNameCase(final String playerName) {
-        return nameToCorrectName.get(playerName);
-    }
-    
-    /**
-     * Find all player names starting with a certain string (not case sensitive).
-     * This method will return the names of offline players as well as online players.
-     */
-    public synchronized static Set<String> getAllPlayerNamesCaseinsensitivelyStartingWith(final String startOfName) {
-        Set<String> ret = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-        
-        String lowercaseStartOfName = startOfName.toLowerCase();
-        
-        // Try to fetch from the cache
-        Set<String> cachedNames = lowerCaseStartOfNameToCorrectNames.get(lowercaseStartOfName);
-        if (cachedNames != null) {
-            ret.addAll(cachedNames);
-            return ret;
-        }
-        
-        // Build it the hard way if cache did not exist
-        
-        ret = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-        for (String correctName : nameToCorrectName.values()) {
-            if (correctName.toLowerCase().startsWith(lowercaseStartOfName)) {
-                ret.add(correctName);
-            }
-        }
-        
-        // Add it to the cache
-        Set<String> shallowCopyForCache = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-        shallowCopyForCache.addAll(ret);
-        lowerCaseStartOfNameToCorrectNames.put(lowercaseStartOfName, shallowCopyForCache);
-        
-        return ret;
-    }
-    
-    /**
      * In Minecraft a playername can be 16 characters long. One sign line is however only 15 characters long.
      * If we find a 15 character long playername on a sign it could thus refer to more than one player.
      * This method finds all possible matching player names.
      */
-    public static Set<String> interpretPlayerNameFromSign(String playerNameFromSign) {
-        Set<String> ret = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-        
-        if (playerNameFromSign.length() > 15) {
-            // This case will in reality not happen.
-            ret.add(playerNameFromSign);
-            return ret;
-        }
-        
-        if (playerNameFromSign.length() == 15) {
-            ret.addAll(PlayerNameUtil.getAllPlayerNamesCaseinsensitivelyStartingWith(playerNameFromSign));
-        } else {
-            String fixedPlayerName = PlayerNameUtil.fixPlayerNameCase(playerNameFromSign);
-            if (fixedPlayerName != null) {
-                ret.add(fixedPlayerName);
-            }
-        }
-        
-        return ret;
+    public static String interpretSignName(String playerNameFromSign) {
+        return playerNameFromSign.length() < 15 ? playerNameFromSign
+                : lowerCaseStartOfNameToCorrectNames.get(playerNameFromSign.toLowerCase());
     }
-    
+
     /**
      * It seems the OfflinePlayer#getLastPlayed in Bukkit is broken.
      * It occasionally returns invalid values. Therefore we use this instead.
-     * The playerName must be the full name but is not case sensitive. 
+     * The playerName must be the full name but is not case sensitive.
      */
+    /* TODO: Was this fixed?
     public static long getLastPlayed(String playerName) {
-	String playerNameCC = fixPlayerNameCase(playerName);
-	if (playerNameCC == null) return 0;
-		
-	Player player = Bukkit.getPlayerExact(playerNameCC);
-	if (player != null && player.isOnline()) return System.currentTimeMillis();
-	
-	File playerFile = new File(playerfolder, playerNameCC+".dat");
-	return playerFile.lastModified();
-    }
+        String playerNameCC = fixPlayerNameCase(playerName);
+        if (playerNameCC == null) return 0;
+
+        Player player = Bukkit.getPlayerExact(playerNameCC);
+        if (player != null && player.isOnline()) return System.currentTimeMillis();
+
+        File playerFile = new File(playerfolder, playerNameCC+".dat");
+        return playerFile.lastModified();
+    }*/
     
     // -------------------------------------------- //
     // INTERNAL METHODS
     // -------------------------------------------- //
     
     protected synchronized static void populateCaseInsensitiveNameToCaseCorrectName()
-    {   
-        // Check if listFiles returns null (ie folder does not exist)
-        File[] files = playerfolder.listFiles();
-		if (files == null) {
-            return;
+    {
+        // We can't use the files here anymore because they were changed to UUIDs with Minecraft 1.7.6+ :/
+        // This way is definetly slower, but there is no better way currently
+        for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            checkPlayer(player);
         }
-        // Populate by removing .dat
-        for (File playerfile : files)
-        {
-            String filename = playerfile.getName();
-            String playername = filename.substring(0, filename.length()-4);
-            nameToCorrectName.put(playername, playername);
+    }
+
+    protected static void checkPlayer(OfflinePlayer player) {
+        String name = player.getName();
+        if (name.length() >= 15) {
+            String start = name.substring(0, 15).toLowerCase();
+            if (!player.isOnline()) {
+                String otherPlayer = lowerCaseStartOfNameToCorrectNames.get(start);
+                // We can't know which player is the correct one, so we just use the one that has last played
+                if (otherPlayer == null || UUIDs.getPlayer(otherPlayer).getLastPlayed() < player.getLastPlayed())
+                    lowerCaseStartOfNameToCorrectNames.put(start, player.getName());
+            } else
+                lowerCaseStartOfNameToCorrectNames.put(start, player.getName());
         }
     }
 }

--- a/src/main/java/com/daemitus/deadbolt/UUIDs.java
+++ b/src/main/java/com/daemitus/deadbolt/UUIDs.java
@@ -1,0 +1,83 @@
+package com.daemitus.deadbolt;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+
+public final class UUIDs {
+    private static final Pattern USER_NAME = Pattern.compile("^[a-zA-Z0-9_]{2,16}$");
+
+    public static boolean isName(String name) {
+        return USER_NAME.matcher(name).matches();
+    }
+
+    public static OfflinePlayer getPlayer(String name) {
+        return Bukkit.getOfflinePlayer(name);
+    }
+
+    public static UUID convertName(String name) {
+        return getPlayer(name).getUniqueId();
+    }
+
+    public static String formatName(String name) {
+        return format(convertName(name));
+    }
+
+    public static String format(OfflinePlayer player) {
+        return format(player.getUniqueId());
+    }
+
+    public static String format(UUID uuid) {
+        char[] buf = new char[8];
+        long most = uuid.getMostSignificantBits(), least = uuid.getLeastSignificantBits();
+        for (int i = 0; i < 4; i++) {
+            buf[i] = (char) ((most >> (16*(4-i))) & 0xffff);
+            buf[4+i] = (char) ((least >> (16*(4-i))) & 0xffff);
+        }
+        return new String(buf);
+    }
+
+    public static boolean validate(String line) {
+        return line.length() == 8;
+    }
+
+    public static UUID get(String line) {
+        Preconditions.checkArgument(validate(line), "Invalid UUID length");
+        long most = 0, least = 0;
+        for (int i = 0; i < 4; i++) {
+            most |= (long) line.charAt(i) << (16*(4-i));
+            least |= (long) line.charAt(4+i) << (16*(4-i));
+        }
+        return new UUID(most, least);
+    }
+
+    public static OfflinePlayer getPlayer(UUID uuid) {
+        return Bukkit.getOfflinePlayer(uuid);
+    }
+
+    public static void deobfuscate(Sign sign, final Player player) {
+        boolean isPrivate = Deadbolt.getLanguage().isPrivate(Util.getLine(sign, 0));
+        boolean isMoreUsers = Deadbolt.getLanguage().isMoreUsers(Util.getLine(sign, 0));
+        if (!(isPrivate || isMoreUsers)) return;
+        final String[] display = sign.getLines().clone();
+        for (int i = 1; i < 4; i++) {
+            String line = Util.getLine(display, i);
+            if (validate(line))
+                display[i] = getPlayer(get(line)).getName();
+        }
+        final Location loc = sign.getLocation();
+        Bukkit.getScheduler().runTaskLater(Deadbolt.getPlugin(), new Runnable() {
+            @Override
+            public void run() {
+                player.sendSignChange(loc, display);
+            }
+        }, 5);
+    }
+}

--- a/src/main/java/com/daemitus/deadbolt/Util.java
+++ b/src/main/java/com/daemitus/deadbolt/Util.java
@@ -1,6 +1,9 @@
 package com.daemitus.deadbolt;
 
+import java.util.UUID;
 import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
 
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
@@ -8,9 +11,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
 
 public final class Util {
-
-    protected static final String patternBracketTooLong = "\\[.{14,}\\]";
-    private static final Pattern PSEUDO_COLOR = Pattern.compile("\\&([0-9a-f])");
 
     public static int blockFaceToNotch(BlockFace face) {
         switch (face) {
@@ -31,24 +31,9 @@ public final class Util {
         }
     }
 
-    public static String formatForSign(String line, int maxlen) {
-        line = removeColor(line);
-        line = line.substring(0, line.length() > maxlen ? maxlen : line.length());
-        return line;
-    }
-
     public static String formatForSign(String line) {
-        return formatForSign(line, 15);
-    }
-
-    public static boolean signNameEqualsPlayerName(String signName, String playerName) {
-        String playerName15 = formatForSign(playerName);
-
-        if (signName.equalsIgnoreCase(playerName15)) {
-            return true;
-        }
-
-        return false;
+        // Bukkit does already verify the max length of the line
+        return removeColor(line);
     }
 
     public static Block getSignAttached(Sign signState) {
@@ -62,18 +47,11 @@ public final class Util {
         return ChatColor.stripColor(text);
     }
 
-    public static String createColor(String text) {
-        return text == null ? null : PSEUDO_COLOR.matcher(text).replaceAll("\u00A7$1");
-    }
-
     public static String getLine(Sign signBlock, int line) {
         return removeColor(signBlock.getLine(line));
     }
 
-    public static String truncate(String text) {
-        if (text.matches(patternBracketTooLong)) {
-            return "[" + text.substring(1, 14) + "]";
-        }
-        return text;
+    public static String getLine(String[] lines, int line) {
+        return removeColor(lines[line]);
     }
 }

--- a/src/main/java/com/daemitus/deadbolt/events/BlockListener.java
+++ b/src/main/java/com/daemitus/deadbolt/events/BlockListener.java
@@ -32,9 +32,9 @@ public class BlockListener implements Listener {
         Player player = event.getPlayer();
         Deadbolted db = Deadbolt.get(block);
 
-        if (db.isProtected() && !db.isAutoExpired() && !db.isOwner(player)) {
+        if (db.isProtected() && !db.isOwner(player) && !db.isAutoExpired()) {
             if (player.hasPermission(Perm.admin_break)) {
-                Deadbolt.getConfig().sendBroadcast(Perm.admin_broadcast_break, ChatColor.RED, Deadbolt.getLanguage().msg_admin_break, player.getName(), db.getOwner());
+                Deadbolt.getConfig().sendBroadcast(Perm.admin_broadcast_break, ChatColor.RED, Deadbolt.getLanguage().msg_admin_break, player.getName(), db.getOwnerName());
             } else {
                 Deadbolt.getConfig().sendMessage(player, ChatColor.RED, Deadbolt.getLanguage().msg_deny_block_break);
                 event.setCancelled(true);


### PR DESCRIPTION
This will update Deadbolt to support UUIDs. It will put the UUIDs into an 8 character string, in most cases they will be Chinese characters. Because we don't know where a Deadbolt sign is they will only show the correct user name if they're clicked by the player first. This could be probably prevented by checking all outgoing packets or something similar but that would be pretty inefficient.

Exisiting signs are converted once they're used for the first time. If multiple user names with the same prefix over 15 characters are available then it is converted to the player that played on the server before the other ones - there is no way to check which player is the real one.
