### PR TITLE
Fully updated to support new 1.8 blocks:

### DIFF
--- a/src/main/java/com/daemitus/deadbolt/Config.java
+++ b/src/main/java/com/daemitus/deadbolt/Config.java
@@ -2,15 +2,17 @@ package com.daemitus.deadbolt;
 
 import com.md_5.config.AnnotatedConfig;
 import com.md_5.config.ConfigComment;
-import java.util.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.*;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -50,7 +52,19 @@ public class Config extends AnnotatedConfig {
     @ConfigComment("Denies Hopper Minecart from interacting with protected blocks")
     public boolean deny_hoppercart = true;
     @ConfigComment("List of blockIDs protected by redstone unless overrode by [everyone]")
-    public List<Integer> redstone_protected_blockids = Arrays.asList(64, 71, 96);
+    public List<Integer> redstone_protected_blockids = Arrays.asList(
+            // Doors
+            Material.WOODEN_DOOR.getId(),
+            Material.IRON_DOOR_BLOCK.getId(),
+            Material.SPRUCE_DOOR.getId(),
+            Material.BIRCH_DOOR.getId(),
+            Material.JUNGLE_DOOR.getId(),
+            Material.ACACIA_DOOR.getId(),
+            Material.DARK_OAK_DOOR.getId(),
+            // trap doors
+            Material.TRAP_DOOR.getId(),
+            Material.IRON_TRAPDOOR.getId()
+    );
     @ConfigComment("Denies function of the [timer: x] tag on signs")
     public boolean deny_timed_doors = false;
     @ConfigComment("Forces timed doors on every protected (trap)door")

--- a/src/main/java/com/daemitus/deadbolt/DeadboltCommandExecutor.java
+++ b/src/main/java/com/daemitus/deadbolt/DeadboltCommandExecutor.java
@@ -150,10 +150,14 @@ public class DeadboltCommandExecutor implements CommandExecutor {
             case JUNGLE_DOOR:
             case ACACIA_DOOR:
             case DARK_OAK_DOOR:
-                block.setData((byte) (block.getData() ^ 0x4));
-                break;
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 block.setData((byte) (block.getData() ^ 0x4));
                 break;
             default:
@@ -188,7 +192,13 @@ public class DeadboltCommandExecutor implements CommandExecutor {
             case ACACIA_DOOR:
             case DARK_OAK_DOOR:
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 for (Block b : db.getBlocks()) {
                     if (b.getType().equals(block.getType())) {
                         b.setData((byte) (b.getData() ^ 0x4));

--- a/src/main/java/com/daemitus/deadbolt/Language.java
+++ b/src/main/java/com/daemitus/deadbolt/Language.java
@@ -1,10 +1,11 @@
 package com.daemitus.deadbolt;
 
 import com.md_5.config.AnnotatedConfig;
-import java.util.regex.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.bukkit.block.Sign;
+
+import java.util.regex.Pattern;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/daemitus/deadbolt/events/BlockListener.java
+++ b/src/main/java/com/daemitus/deadbolt/events/BlockListener.java
@@ -7,7 +7,6 @@ import com.daemitus.deadbolt.Perm;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import static org.bukkit.Material.HOPPER;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
@@ -104,6 +103,7 @@ public class BlockListener implements Listener {
                 }
                 return;
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
                 if (player.hasPermission(getPermission(block.getType())) && Deadbolt.getConfig().reminder.add(player)) {
                     Deadbolt.getConfig().sendMessage(player, ChatColor.GOLD, Deadbolt.getLanguage().msg_reminder_lock_your_chests);
                 }
@@ -113,6 +113,11 @@ public class BlockListener implements Listener {
                 }
                 return;
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 if (player.hasPermission(getPermission(block.getType())) && Deadbolt.getConfig().reminder.add(player)) {
                     Deadbolt.getConfig().sendMessage(player, ChatColor.GOLD, Deadbolt.getLanguage().msg_reminder_lock_your_chests);
                 }
@@ -157,8 +162,14 @@ public class BlockListener implements Listener {
             case DARK_OAK_DOOR:
                 return Perm.user_create_door;
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
                 return Perm.user_create_trapdoor;
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 return Perm.user_create_fencegate;
             case ANVIL:
                 return Perm.user_create_anvil;

--- a/src/main/java/com/daemitus/deadbolt/events/PlayerListener.java
+++ b/src/main/java/com/daemitus/deadbolt/events/PlayerListener.java
@@ -3,6 +3,7 @@ package com.daemitus.deadbolt.events;
 import com.daemitus.deadbolt.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -48,7 +49,13 @@ public class PlayerListener implements Listener {
             case ACACIA_DOOR:
             case DARK_OAK_DOOR:
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 return onPlayerInteractDoor(event);
             case CHEST:
             case TRAPPED_CHEST:
@@ -84,8 +91,14 @@ public class PlayerListener implements Listener {
             case ACACIA_DOOR:
             case DARK_OAK_DOOR:
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
             case TRAPPED_CHEST:
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
             case BREWING_STAND:
             case ENCHANTMENT_TABLE:
             case CAULDRON:
@@ -134,7 +147,10 @@ public class PlayerListener implements Listener {
 
                 signState.update(true);
                 ItemStack held = player.getItemInHand();
-                held.setAmount(held.getAmount() - 1);
+                // Don't reduce amount for creative mode players
+                if (!player.getGameMode().equals(GameMode.CREATIVE))
+                    held.setAmount(held.getAmount() - 1);
+
                 if (held.getAmount() == 0) {
                     player.setItemInHand(null);
                 }
@@ -157,7 +173,6 @@ public class PlayerListener implements Listener {
             case DISPENSER:
                 return player.hasPermission(Perm.user_create_dispenser);
             case FURNACE:
-                return player.hasPermission(Perm.user_create_furnace);
             case BURNING_FURNACE:
                 return player.hasPermission(Perm.user_create_furnace);
             case WOODEN_DOOR:
@@ -166,12 +181,17 @@ public class PlayerListener implements Listener {
             case JUNGLE_DOOR:
             case ACACIA_DOOR:
             case DARK_OAK_DOOR:
-                return player.hasPermission(Perm.user_create_door);
             case IRON_DOOR_BLOCK:
                 return player.hasPermission(Perm.user_create_door);
             case TRAP_DOOR:
+            case IRON_TRAPDOOR:
                 return player.hasPermission(Perm.user_create_trapdoor);
             case FENCE_GATE:
+            case BIRCH_FENCE_GATE:
+            case ACACIA_FENCE_GATE:
+            case DARK_OAK_FENCE_GATE:
+            case JUNGLE_FENCE_GATE:
+            case SPRUCE_FENCE_GATE:
                 return player.hasPermission(Perm.user_create_fencegate);
             case BREWING_STAND:
                 return player.hasPermission(Perm.user_create_brewery);

--- a/src/main/java/com/daemitus/deadbolt/events/SignListener.java
+++ b/src/main/java/com/daemitus/deadbolt/events/SignListener.java
@@ -31,7 +31,7 @@ public class SignListener implements Listener {
         Block block = event.getBlock();
         String[] lines = event.getLines();
 
-        //fix for clientside sign edit hack
+        //fix for client-side sign edit hack
         if (event.getBlock().getType().equals(Material.WALL_SIGN)) {
             Sign sign = (Sign) event.getBlock().getState();
             String ident = Util.getLine(sign, 0);
@@ -190,11 +190,17 @@ public class SignListener implements Listener {
                             }
                             break;
                         case TRAP_DOOR:
+                        case IRON_TRAPDOOR:
                             if (!trap && !(trap = player.hasPermission(Perm.user_create_trapdoor))) {
                                 return Result.DENY_BLOCK_PERM;
                             }
                             break;
                         case FENCE_GATE:
+                        case BIRCH_FENCE_GATE:
+                        case ACACIA_FENCE_GATE:
+                        case DARK_OAK_FENCE_GATE:
+                        case JUNGLE_FENCE_GATE:
+                        case SPRUCE_FENCE_GATE:
                             if (!gate && !(gate = player.hasPermission(Perm.user_create_fencegate))) {
                                 return Result.DENY_BLOCK_PERM;
                             }


### PR DESCRIPTION
- Added Iron Trap Door support
- Added proper vertical and horizontal chaining for both Wooden and Iron Trap Doors
- Wooden Trap Door no longer gets out of sync when a sign is placed on a row/column of Trap Doors
- Added the 5 new fence gates (Birch, Acacia, Dark Oak, Jungle, & Spruce)
- Signs are no longer removed from the player's hand when in Creative Mode
- Added the new doors and trap door to the default redstone protection list
- Signs placed above the new doors now no longer returns "Nothing nearby to protect"
